### PR TITLE
Specify '-std=c99' option explicitly for older GCC

### DIFF
--- a/lib/Devel/CheckCompiler.pm
+++ b/lib/Devel/CheckCompiler.pm
@@ -39,6 +39,8 @@ sub _is_gcc {
     return 0 if $Config{gccversion} eq '';
     # For clang on MacOSX and *BSD distributions
     return 0 if $Config{gccversion} =~ m/clang/i;
+    # For Intel C and C++ compiler
+    return 0 if $Config{gccversion} =~ m/intel/i;
 
     return 1;
 }


### PR DESCRIPTION
Before GCC 5.0, '-std=gnu89' is default. 'gnu89' does not have some C99
features such as for loop initial declaration. C99 test is more strict
from 782a0004bb2e3a81d238dc842a32fb555d83600, and it fails with '-std=gnu89'.
So we should add '-std=c99' option explicitly for older GCC.